### PR TITLE
BUG: Declare Superclass's SetNthInput function to fix compiler warnings.

### DIFF
--- a/include/itkImageToImageOfVectorsFilter.h
+++ b/include/itkImageToImageOfVectorsFilter.h
@@ -77,6 +77,8 @@ public:
 
   using DataObjectPointerArraySizeType = typename Superclass::DataObjectPointerArraySizeType;
 
+  using Superclass::SetNthInput;
+
   virtual void
   SetNthInput(DataObjectPointerArraySizeType idx, const InputImageType * inputImage)
   {


### PR DESCRIPTION
When compiled against ITKv5.1 and clang 11, a `-Woverloaded-virtual` warning is thrown. Declaring the superclass's `SetNthInput` function in the subclass by stating `using Superclass::SetNthInput;` resolves this warning.

This resolves issue #13.