### PR TITLE
STYLE: Rename ITK_DISALLOW_COPY_AND_ASSIGN to ITK_DISALLOW_COPY_AND_MOVE

### DIFF
--- a/include/itkBSplineApproximationGradientImageFilter.h
+++ b/include/itkBSplineApproximationGradientImageFilter.h
@@ -50,7 +50,7 @@ class ITK_TEMPLATE_EXPORT BSplineApproximationGradientImageFilter
       Image<CovariantVector<TOutputValueType, TInputImage::ImageDimension>, TInputImage::ImageDimension>>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(BSplineApproximationGradientImageFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(BSplineApproximationGradientImageFilter);
 
   itkStaticConstMacro(ImageDimension, unsigned int, TInputImage::ImageDimension);
 

--- a/include/itkBSplineGradientImageFilter.h
+++ b/include/itkBSplineGradientImageFilter.h
@@ -44,7 +44,7 @@ class ITK_TEMPLATE_EXPORT BSplineGradientImageFilter
       Image<CovariantVector<TOutputValueType, TInputImage::ImageDimension>, TInputImage::ImageDimension>>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(BSplineGradientImageFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(BSplineGradientImageFilter);
 
   /** Extract dimension from input image. */
   itkStaticConstMacro(ImageDimension, unsigned int, TInputImage::ImageDimension);

--- a/include/itkBSplineScatteredDataPointSetToGradientImageFilter.h
+++ b/include/itkBSplineScatteredDataPointSetToGradientImageFilter.h
@@ -56,7 +56,7 @@ class BSplineScatteredDataPointSetToGradientImageFilter
       Image<CovariantVector<TOutputValueType, TInputPointSet::PointDimension>, TInputPointSet::PointDimension>>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(BSplineScatteredDataPointSetToGradientImageFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(BSplineScatteredDataPointSetToGradientImageFilter);
 
   /** Extract dimension from input image. */
   itkStaticConstMacro(PointSetDimension, unsigned int, TInputPointSet::PointDimension);

--- a/include/itkImageToImageOfVectorsFilter.h
+++ b/include/itkImageToImageOfVectorsFilter.h
@@ -55,7 +55,7 @@ class ITK_TEMPLATE_EXPORT ImageToImageOfVectorsFilter
       Image<Vector<typename TInputImage::InternalPixelType, NComponents>, TInputImage::ImageDimension>>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(ImageToImageOfVectorsFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(ImageToImageOfVectorsFilter);
 
   using Superclass = ImageToImageFilter<
     TInputImage,

--- a/include/itkImageToPointSetFilter.h
+++ b/include/itkImageToPointSetFilter.h
@@ -38,7 +38,7 @@ template <typename TInputImage, typename TOutputMesh>
 class ITK_TEMPLATE_EXPORT ImageToPointSetFilter : public ImageToMeshFilter<TInputImage, TOutputMesh>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(ImageToPointSetFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(ImageToPointSetFilter);
 
   /** Standard class type alias. */
   using Self = ImageToPointSetFilter;


### PR DESCRIPTION
This PR fixes changes made in [#2053](https://github.com/InsightSoftwareConsortium/ITK/pull/2053/commits/4eac1a0cfb456fad1e3894173a41d7c7de49b08f). Essentially, `ITK_DISALLOW_COPY_AND_ASSIGN` has been changed to `ITK_DISALLOW_COPY_AND_MOVE` to more accurately convey the actions taking place. `ITK_DISALLOW_COPY_AND_ASSIGN` will **only** be used if `ITK_FUTURE_LEGACY_REMOVE=OFF`.

**NOTE:** These changes will cause the GitHub Actions to break, because they currently build `ITK v5.1.0`. The errors persist with `v5.1.1` as well (will update to newest version in separate PR). When tested locally against `master`, I get all tests to pass. The case is the same for the remaining 39 remote modules.