### PR TITLE
COMP: Remove inclusion of .hxx files as headers

### DIFF
--- a/include/itkBSplineApproximationGradientImageFilter.hxx
+++ b/include/itkBSplineApproximationGradientImageFilter.hxx
@@ -18,7 +18,6 @@
 #ifndef itkBSplineApproximationGradientImageFilter_hxx
 #define itkBSplineApproximationGradientImageFilter_hxx
 
-#include "itkBSplineApproximationGradientImageFilter.h"
 
 namespace itk
 {

--- a/include/itkBSplineGradientImageFilter.hxx
+++ b/include/itkBSplineGradientImageFilter.hxx
@@ -18,7 +18,6 @@
 #ifndef itkBSplineGradientImageFilter_hxx
 #define itkBSplineGradientImageFilter_hxx
 
-#include "itkBSplineGradientImageFilter.h"
 
 #include "itkImageRegionIteratorWithIndex.h"
 

--- a/include/itkBSplineScatteredDataPointSetToGradientImageFilter.hxx
+++ b/include/itkBSplineScatteredDataPointSetToGradientImageFilter.hxx
@@ -18,7 +18,6 @@
 #ifndef itkBSplineScatteredDataPointSetToGradientImageFilter_hxx
 #define itkBSplineScatteredDataPointSetToGradientImageFilter_hxx
 
-#include "itkBSplineScatteredDataPointSetToGradientImageFilter.h"
 
 #include "itkImageRegionIteratorWithIndex.h"
 #include "itkNeighborhoodAlgorithm.h" // face calculator

--- a/include/itkImageToImageOfVectorsFilter.hxx
+++ b/include/itkImageToImageOfVectorsFilter.hxx
@@ -18,7 +18,6 @@
 #ifndef itkImageToImageOfVectorsFilter_hxx
 #define itkImageToImageOfVectorsFilter_hxx
 
-#include "itkImageToImageOfVectorsFilter.h"
 
 #include "itkImageRegionIterator.h"
 

--- a/include/itkImageToPointSetFilter.hxx
+++ b/include/itkImageToPointSetFilter.hxx
@@ -18,7 +18,6 @@
 #ifndef itkImageToPointSetFilter_hxx
 #define itkImageToPointSetFilter_hxx
 
-#include "itkImageToPointSetFilter.h"
 
 #include "itkImageRegionConstIteratorWithIndex.h"
 #include "itkProgressReporter.h"


### PR DESCRIPTION
COMP: Remove inclusion of .hxx files as headers

The ability to include either .h or .hxx files as
header files required recursively reading the
.h files twice.  The added complexity is
unnecessary, costly, and can confuse static
analysis tools that monitor header guardes (due
to reaching the maximum depth of recursion
limits for nested #ifdefs in checking).

