### PR TITLE
ENH: Bump to ITK v5.3rc04.post3

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -3,8 +3,9 @@ name: Build, test, package
 on: [push,pull_request]
 
 env:
-  itk-git-tag: "835dc01388d22c4b4c9a46b01dbdfe394ec23511"
-  itk-wheel-tag: "v5.3rc04.post2" # Same ITK C++ reference commit, different tag name
+  itk-git-tag: "171fb2ba33a87041f99328a2f26612ff33aa9cc8"
+  itk-wheel-tag: "v5.3rc04.post3" # Same ITK C++ reference commit, different tag name
+  ITKMeshToPolyData-git-tag: "v0.9.1"
 
 jobs:
   build-test-cxx:
@@ -12,9 +13,9 @@ jobs:
     strategy:
       max-parallel: 3
       matrix:
-        os: [ubuntu-18.04, windows-2019, macos-10.15]
+        os: [ubuntu-20.04, windows-2019, macos-11]
         include:
-          - os: ubuntu-18.04
+          - os: ubuntu-20.04
             c-compiler: "gcc"
             cxx-compiler: "g++"
             cmake-build-type: "MinSizeRel"
@@ -22,7 +23,7 @@ jobs:
             c-compiler: "cl.exe"
             cxx-compiler: "cl.exe"
             cmake-build-type: "Release"
-          - os: macos-10.15
+          - os: macos-11
             c-compiler: "clang"
             cxx-compiler: "clang++"
             cmake-build-type: "MinSizeRel"
@@ -157,6 +158,7 @@ jobs:
     - name: 'Build 🐍 Python 📦 package'
       run: |
         export ITK_PACKAGE_VERSION=${{ env.itk-wheel-tag }}
+        export TARBALL_SPECIALIZATION="-manylinux_2_28"
         pwd
         git clone https://github.com/InsightSoftwareConsortium/ITKMeshToPolyData.git
         echo "Building ITKMeshToPolyData dependency"
@@ -178,7 +180,7 @@ jobs:
         path: dist
 
   build-macos-python-packages:
-    runs-on: macos-10.15
+    runs-on: macos-11
     strategy:
       max-parallel: 2
 
@@ -187,7 +189,7 @@ jobs:
 
     - name: 'Specific XCode version'
       run: |
-        sudo xcode-select -s "/Applications/Xcode_11.7.app"
+        sudo xcode-select -s "/Applications/Xcode_13.2.1.app"
 
     - name: Get specific version of CMake, Ninja
       uses: lukka/get-cmake@v3.18.3
@@ -284,7 +286,7 @@ jobs:
       - build-linux-python-packages
       - build-macos-python-packages
       - build-windows-python-packages
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
     - name: Download Python Packages

--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -168,7 +168,7 @@ jobs:
         ./dockcross-manylinux-download-cache-and-build-module-wheels.sh cp${{ matrix.python-version }}
         popd
         cp ITKMeshToPolyData/include/* include/
-        rm ./ITKMeshToPolyData/ITKPythonBuilds-linux.tar.zst
+        rm -f ./ITKMeshToPolyData/ITKPythonBuilds-linux.tar.zst
         mv ./ITKMeshToPolyData/ITKPythonPackage .
         echo "Building ITKBSplineGradient"
         ./dockcross-manylinux-download-cache-and-build-module-wheels.sh cp${{ matrix.python-version }}
@@ -212,7 +212,7 @@ jobs:
         ./macpython-download-cache-and-build-module-wheels.sh
         popd
         cp ITKMeshToPolyData/include/* include/
-        rm ./ITKMeshToPolyData/ITKPythonBuilds-macosx.tar.zst
+        rm -f ./ITKMeshToPolyData/ITKPythonBuilds-macosx.tar.zst
         echo "Building ITKBSplineGradient"
         ./macpython-download-cache-and-build-module-wheels.sh
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ except ImportError:
 
 setup(
     name='itk-bsplinegradient',
-    version='0.2.8',
+    version='0.2.9',
     author='Matthew McCormick',
     author_email='matt.mccormick@kitware.com',
     packages=['itk'],
@@ -46,6 +46,7 @@ setup(
     keywords='ITK InsightToolkit Image-Gradient B-spline',
     url=r'https://github.com/InsightSoftwareConsortium/ITKBSplineGradient',
     install_requires=[
-        r'itk>=v5.3rc04.post2'
+        r'itk>=v5.3rc04.post3',
+        r'itk-meshtopolydata>=v0.9.1'
     ]
     )


### PR DESCRIPTION
ITKBSplineGradient has a dependency on ITKMeshToPolyData and so is not yet supported by the new ITK reusable pipeline.

For this pass I have only updated for `_2_28` packages. May need to revisit to understand how building dependencies for multiple architectures affects CI duration.